### PR TITLE
Swift 3.1 and added @escaping to PageLoader

### DIFF
--- a/Sourcery/Sourcery.xcodeproj/project.pbxproj
+++ b/Sourcery/Sourcery.xcodeproj/project.pbxproj
@@ -446,7 +446,7 @@
 				PRODUCT_NAME = Sourcery;
 				SKIP_INSTALL = YES;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
-				SWIFT_VERSION = 3.0.1;
+				SWIFT_VERSION = 3.0;
 			};
 			name = Debug;
 		};
@@ -466,7 +466,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.nodes.Sourcery;
 				PRODUCT_NAME = Sourcery;
 				SKIP_INSTALL = YES;
-				SWIFT_VERSION = 3.0.1;
+				SWIFT_VERSION = 3.0;
 			};
 			name = Release;
 		};

--- a/Sourcery/Sourcery/Classes/Sourcery/PagedSourcery.swift
+++ b/Sourcery/Sourcery/Classes/Sourcery/PagedSourcery.swift
@@ -11,7 +11,7 @@ import PagedArray
 
 open class PagedSourcery<DataType, CellType: TableViewPresentable>: NSObject, TableController {
 
-    public typealias PageLoader = ((_ page: Int, _ operationQueue: OperationQueue, _ completion: ((_ totalCount: Int, _ data: [DataType]) -> Void)) -> Void)
+    public typealias PageLoader = ((_ page: Int, _ operationQueue: OperationQueue, _ completion: @escaping ((_ totalCount: Int, _ data: [DataType]) -> Void)) -> Void)
     public typealias SelectionHandler = ((_ index: Int, _ object: DataType) -> Void)
     public typealias CellConfigurator = ((_ cell: CellType, _ index: Int, _ object: DataType) -> Void)
     public typealias HeaderConfigurator = ((UITableViewHeaderFooterView?) -> Void)


### PR DESCRIPTION
Calling the completionHandler of a PagedSourcery initializer's PageLoader parameter from within an escapable closure creates a compiler error without the `@escapable` flag added to it. 

Also updated project settings to Swift 3.1